### PR TITLE
Update chash.lua

### DIFF
--- a/chash.lua
+++ b/chash.lua
@@ -85,7 +85,7 @@ local function chash_init()
 end
 
 local function chash_get_upstream(key)
-	if not initialized then
+	if not M.initialized then
 		chash_init()
 	end
 


### PR DESCRIPTION
The lack of M.initialized.
Every time this kind of situation will cause the judgment for does not exist, each call to initialize.
