### PR TITLE
Fix typo in argument variable

### DIFF
--- a/chash.lua
+++ b/chash.lua
@@ -101,7 +101,7 @@ local function chash_get_upstream(key)
 end
 M.get_upstream = chash_get_upstream
 
-local function chash_add_upstream(upstream, weigth)
+local function chash_add_upstream(upstream, weight)
 	M.initialized = false
 
 	weight = weight or 1


### PR DESCRIPTION
Fixes a typo in the `weight` argument of `chash_add_upstream`... the original misspelling caused the method to treat the argument and the assigned weight as different values.